### PR TITLE
[reports] Change parameters order in find_obs_pkg to avoid reaching the limit.

### DIFF
--- a/src/reports/repo/utils.py
+++ b/src/reports/repo/utils.py
@@ -470,8 +470,8 @@ def _find_obs_pkg(bs, pkg, src_project):
         return pkg
     else:
 
-        predicate = "(contains(@name , '%s')) and path/@project='%s'" % (
-            pkg, src_project
+        predicate = "@project='%s' and contains(@name, '%s')" % (
+            src_project, pkg
         )
         kwa = {path: predicate}
         print kwa


### PR DESCRIPTION
When searching for a `qt5` package for a specific project in `find_obs_pkg`, the `413 Search limit reached` error raised from obs api. 
Swapped the search criteria to optimize the search.